### PR TITLE
Remove redundant self in score_corpus

### DIFF
--- a/smatchpp/bindings.py
+++ b/smatchpp/bindings.py
@@ -126,7 +126,7 @@ class Smatchpp():
     
     def score_corpus(self, amrs, amrs2):
         
-        match_dict, status = self.process_corpus(self, amrs, amrs2)
+        match_dict, status = self.process_corpus(amrs, amrs2)
         
         final_result = None
 


### PR DESCRIPTION
Resolves this error:
TypeError: Smatchpp.process_corpus() takes 3 positional arguments but 4 were given